### PR TITLE
Error handling on DNS resolution fail

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,11 @@ module.exports = (program, config, relativeRoot) => {
     if (!resolved[req.headers.host]) {
       // If not, resolve & save.
       dns.resolve(req.headers.host, (err, resp) => {
+        if (err) {
+          res.writeHead(500);
+          res.end(`Could not resolve ${req.headers.host}`);
+          return;
+        }
         console.log('resolved %s to %s', req.headers.host, resp[0]);
         resolved[req.headers.host] = resp[0];
         go(resp[0]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mostess",
+  "name": "@abcnews/mostess",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Previously we were not catching the error, so Mostess would crash. Now it returns an [error 500](https://http.cat/500) and a warning message.